### PR TITLE
Update PALMETTO_hb.mrw.xml with new DMI lane reversal

### DIFF
--- a/PALMETTO_hb.mrw.xml
+++ b/PALMETTO_hb.mrw.xml
@@ -1263,7 +1263,7 @@
     </attribute>
     <attribute>
         <id>EI_BUS_TX_LANE_INVERT</id>
-        <default>0x00000000</default>
+        <default>0x31a50000</default>
     </attribute>
 </targetInstance>
 


### PR DESCRIPTION
Norm discovered an error in the MRW. The original palmetto_board.xml has been updated, but we need to make this change until the MRW tools are out.
